### PR TITLE
Remove references to images from CSS that are causing 500s

### DIFF
--- a/chef.py
+++ b/chef.py
@@ -221,6 +221,7 @@ def truncate_metadata(data_string):
 
 
 FONT_SRC_RE = re.compile(r"src:\W?url\(.*?fonts/(.*?)['\"]?\)")
+UP_DIR_IMG_RE = re.compile(r"url\(['\"]../im.*?\)")
 BG_IMG_RE = re.compile("background-image:url\((.*)\)")
 
 with open("resources/font_sizing.css") as f:
@@ -260,8 +261,11 @@ def download_static_assets(doc, destination):
                 filename = match.groups()[0]
                 url = make_fully_qualified_url("fonts/%s" % filename)
                 download_file(url, destination, request_fn=make_request)
-
             processed_css = FONT_SRC_RE.sub(r"src: url('\1')", content)
+
+            # ... and we don't need references to images. Remove them else they
+            # may cause a 500 on the server.
+            processed_css = UP_DIR_IMG_RE.sub('url("")', content)
 
             # ... and then append additional CSS to reduce font sizing to fit
             # better on shorter screens (for previewing in Kolibri's iframe

--- a/chef.py
+++ b/chef.py
@@ -75,6 +75,7 @@ class AfricanStorybookChef(SushiChef):
             title = channel_info['CHANNEL_TITLE'],
             thumbnail = channel_info.get('CHANNEL_THUMBNAIL'),
             description = channel_info.get('CHANNEL_DESCRIPTION'),
+            language= "en",
         )
 
         #download_book("http://www.africanstorybook.org/reader.php?id=16451", "16451", "title", "author", "description", ["en"])

--- a/chef.py
+++ b/chef.py
@@ -108,6 +108,8 @@ class AfricanStorybookChef(SushiChef):
 
 
 def download_all():
+    scraped_ids = set()
+
     with WebDriver("http://www.africanstorybook.org/", delay=20000) as driver:
         books = driver.execute_script("return bookItems;")
         total_books = len(books)
@@ -121,6 +123,10 @@ def download_all():
         channel_tree = defaultdict(lambda: defaultdict(list))
         for i, book in enumerate(books):
             book_id = book["id"]
+            if book_id in scraped_ids:
+                continue
+            scraped_ids.add(book_id)
+
             book_url = "http://www.africanstorybook.org/reader.php?id=%s" % book_id
             print("Downloading book %s of %s with url %s" % (i + 1, total_books, book_url))
 

--- a/chef.py
+++ b/chef.py
@@ -221,7 +221,7 @@ def truncate_metadata(data_string):
 
 
 FONT_SRC_RE = re.compile(r"src:\W?url\(.*?fonts/(.*?)['\"]?\)")
-UP_DIR_IMG_RE = re.compile(r"url\(['\"]../im.*?\)")
+UP_DIR_IMG_RE = re.compile(r"url\(['\"]?../im.*?\)")
 BG_IMG_RE = re.compile("background-image:url\((.*)\)")
 
 with open("resources/font_sizing.css") as f:

--- a/chef.py
+++ b/chef.py
@@ -198,7 +198,7 @@ def download_book(book_url, book_id, title, author, description, languages):
 
     zip_path = create_predictable_zip(destination)
     return nodes.HTML5AppNode(
-        source_id=book_id,
+        source_id=book_url,
         title=truncate_metadata(title),
         license=licenses.CC_BYLicense(
             copyright_holder=truncate_metadata(copyright_holder)),


### PR DESCRIPTION
Addresses this issue: https://trello.com/c/xPhTM4wo/106-african-storybook

> Not sure who's working on the AS chef. An issue in the CSS that needs to be factored into the chef:
> https://contentworkshop.learningequality.org/zipcontent/4d943765ffee150dd89092e12438c2a2.zip/4_app.css
> (it refers to images with patterns like ../image.png, which refers to a path above the root of the zip file, which throws errors on the server)

I've checked that those images aren't actually used, so this pull request removes references to those images entirely, so that we don't get those 500s on the Kolibri server.

Tested by uncommenting `download_book` on line 80 and `preview_in_browser` on line 196, running the chef, verifying the book looks like it did before, and also checking that there are no longer 404s of `left.png` or `right.png` in the JS console (these are the two images causing 500s on the Kolibri demo server, [example here](http://kolibridemo.learningequality.org/learn/#/recommended/c968c44f2e705cd68fd22acbc1f4bb2b)).