### PR TITLE
Update ricecooker requirement to >=0.6.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 le-utils>=0.0.9rc23
-ricecooker>=0.6.3
+ricecooker>=0.6.13


### PR DESCRIPTION
So that we bring in the fix for ensuring all spawned PhantomJS processes get terminated, from https://github.com/learningequality/ricecooker/commit/5b93fdfb2c899157ffcbf44883ff0b356d5e83e5