### PR TITLE
Use `cursor: pointer` instead of resize arrows for click spots

### DIFF
--- a/chef.py
+++ b/chef.py
@@ -313,7 +313,7 @@ def add_page_flipper_buttons(doc, left_png, right_png):
     left_flipper_html = base_flipper_html % {
         "id": "left-flipper",
         "width": width,
-        "style": "left: 0; cursor: w-resize;",
+        "style": "left: 0; cursor: pointer;",
         "onclick": "$$('#go-back').click();",
         "src": left_png,
     }
@@ -321,7 +321,7 @@ def add_page_flipper_buttons(doc, left_png, right_png):
     right_flipper_html = base_flipper_html % {
         "id": "right-flipper",
         "width": width,
-        "style": "right: 0; cursor: e-resize;",
+        "style": "right: 0; cursor: pointer;",
         "onclick": "$$('#go-next').click();",
         "src": right_png,
     }

--- a/resources/font_sizing.css
+++ b/resources/font_sizing.css
@@ -37,3 +37,15 @@
         line-height: 1.7vw !important;
     }
 }
+
+#go-back {
+    cursor: pointer;
+}
+
+#go-next {
+    cursor: pointer;
+}
+
+#readingRange {
+    cursor: pointer;
+}


### PR DESCRIPTION
In #content-dev room on Slack:

> Devon Rueckner [5:14 PM]
> Just a heads-up: I noticed that our HTML5 version of African Storybook uses left- and right-arrow cursors to switch page: https://kolibridemo.learningequality.org/learn/#/topics/c/595a59927ef95069bca8f9eda2d5312f
> typically that cursor means “resize”. would recommend switching to a pointer hand cursor
> https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
> also the slider on the bottom has no hover-state cursor - that should also probably be a pointer hand 

Tested by uncommenting `preview_in_browser()` in `chef.py`.